### PR TITLE
Generate valid class names

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -6,6 +6,9 @@ import loadConfig from 'postcss-load-config'
 import stringHash from 'string-hash'
 import path from 'path'
 
+const cssClassNameRe = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
+const cssClassNameCleanRe = /[^\w\/-]/g
+
 /**
  * Initialize postcss `processor`.
  * Use `deasync` to make async methods sync.
@@ -143,7 +146,10 @@ function generateClassName(src, { basename, filenameRelative }, { namespace = 'c
       const nextPathBlock = pathBlocks[index + 1]
       return !nextPathBlock || nextPathBlock.indexOf(pathBlock) !== 0
     })
-    const className = uniquePathBlocks.join('-')
+    const className = uniquePathBlocks.join('-').replace(cssClassNameCleanRe, '_')
+    if (!cssClassNameRe.test(className)) {
+      console.error(`Warning: invalid CSS class name '${className}'. Validation with regular expression '${cssClassNameRe}' failed.`)
+    }
     const increment = classes.get(className) || 1
     classes.set(className, increment + 1)
     return `.${namespace}-${className}${increment > 1 ? increment : ''}`


### PR DESCRIPTION
This PR is fixing issue with generating invalid CSS class name. It results in missing CSS rules for components which file paths include forbidden characters (`., ~, *, etc.`). For example `.../app.dashboard/...`

- remove invalid characters from generated class name. `app.dashboard => app_dashboard`
- validate final class name value (warning is printed if validation fails).